### PR TITLE
Specify location and name of config file

### DIFF
--- a/rtmbot.py
+++ b/rtmbot.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 import logging
+from argparse import ArgumentParser
 
 from slackclient import SlackClient
 
@@ -164,14 +165,27 @@ def main_loop():
     except:
         logging.exception('OOPS')
 
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument(
+        '-c',
+        '--config',
+        help='Full path to config file.',
+        metavar='path'
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = parse_args()
     directory = os.path.dirname(sys.argv[0])
     if not directory.startswith('/'):
         directory = os.path.abspath("{}/{}".format(os.getcwd(),
                                 directory
                                 ))
 
-    config = yaml.load(file('rtmbot.conf', 'r'))
+    config = yaml.load(file(args.config or 'rtmbot.conf', 'r'))
     debug = config["DEBUG"]
     bot = RtmBot(config["SLACK_TOKEN"])
     site_plugins = []


### PR DESCRIPTION
#### Motivation/User Story
As a DevOps engineer for a Slack bot integration hosting service, I want to be able to specify the config file path so that the configuration of a running instance of python-rtmbot is decoupled from the location of the source code.

This will allow us to run multiple instances of python-rtmbot from the same code base, but with a different configuration (e.g., a different Slack token) for each.  Then we can take all the time we save by deploying/maintaining just one copy of the code and [have a bubble party](https://38.media.tumblr.com/tumblr_mdykfb5JDL1r6u8u7o1_500.gif).

#### What it does
This PR allows a user to specify the location and name of a config file with an optional command-line argument.  The current behavior is still available, which is to say, if the argument is not provided, the `rtmbot.conf` file in the project root is used.

#### Usage
Use the `-c` or `--config` command line option followed by the full path (including file name) of the desired config file:
```bash
$ python ./rtmbot.py -c /path/to/config/my_config.conf
```