### PR TITLE
Make python-rtmbot friendlier to encoding

### DIFF
--- a/doc/example-plugins/counter.py
+++ b/doc/example-plugins/counter.py
@@ -7,4 +7,4 @@ crontable.append([5, "say_time"])
 
 def say_time():
     # NOTE: you must add a real channel ID for this to work
-    outputs.append(["D12345678", time.time()])
+    outputs.append(["D12345678", str(time.time())])

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -101,7 +101,7 @@ class RtmBot(object):
                     if limiter:
                         time.sleep(.1)
                         limiter = False
-                    message = output[1].encode('ascii', 'ignore').encode()
+                    message = output[1].encode('ascii', 'ignore').decode()
                     channel.send_message("{}".format(message))
                     limiter = True
 

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -101,7 +101,7 @@ class RtmBot(object):
                     if limiter:
                         time.sleep(.1)
                         limiter = False
-                    message = output[1].encode('ascii', 'ignore')
+                    message = output[1].encode('ascii', 'ignore').encode()
                     channel.send_message("{}".format(message))
                     limiter = True
 

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -16,12 +16,12 @@ class RtmBot(object):
             Params:
                 - config (dict):
                     - SLACK_TOKEN: your authentication token from Slack
-                    - BASE_PATH (optional: defaults to execution directory) RtmBot will
-                        look in this directory for plugins.
-                    - LOGFILE (optional: defaults to rtmbot.log) The filename for logs, will
-                        be stored inside the BASE_PATH directory
-                    - DEBUG (optional: defaults to False) with debug enabled, RtmBot will
-                        break on errors
+                    - BASE_PATH (optional: defaults to execution directory)
+                        RtmBot will look in this directory for plugins.
+                    - LOGFILE (optional: defaults to rtmbot.log) The filename
+                        for logs, will be stored inside the BASE_PATH directory
+                    - DEBUG (optional: defaults to False) with debug enabled,
+                        RtmBot will break on errors
         '''
         # set the config object
         self.config = config
@@ -132,7 +132,8 @@ class Plugin(object):
             - name (str)
             - plugin config (dict) - (from the yaml config)
                 Values in config:
-                - DEBUG (bool) - this will be overridden if debug is set in config for this plugin
+                - DEBUG (bool) - this will be overridden if debug is set in
+                    config for this plugin
         '''
         if plugin_config is None:
             plugin_config = {}
@@ -149,7 +150,8 @@ class Plugin(object):
     def register_jobs(self):
         if 'crontable' in dir(self.module):
             for interval, function in self.module.crontable:
-                self.jobs.append(Job(interval, eval("self.module." + function), self.debug))
+                self.jobs.append(
+                    Job(interval, eval("self.module." + function), self.debug))
             logging.info(self.module.crontable)
             self.module.crontable = []
         else:
@@ -165,7 +167,8 @@ class Plugin(object):
                 try:
                     eval("self.module." + function_name)(data)
                 except Exception:
-                    logging.exception("problem in module {} {}".format(function_name, data))
+                    logging.exception(
+                        "problem in module {} {}".format(function_name, data))
         if "catch_all" in dir(self.module):
             if self.debug is True:
                 # this makes the plugin fail with stack trace in debug mode
@@ -174,7 +177,9 @@ class Plugin(object):
                 try:
                     self.module.catch_all(data)
                 except Exception:
-                    logging.exception("problem in catch all: {} {}".format(self.module, data))
+                    logging.exception(
+                        "problem in catch all: {} {}".format(
+                            self.module, data))
 
     def do_jobs(self):
         for job in self.jobs:
@@ -217,7 +222,8 @@ class Job(object):
                 try:
                     self.function()
                 except Exception:
-                    logging.exception("Problem in job check: {}".format(self.function))
+                    logging.exception(
+                        "Problem in job check: {}".format(self.function))
             self.lastrun = time.time()
 
 


### PR DESCRIPTION
Hello, 

In __core.py__, the message was still bytes (result of encode()) before being sent to the channel (send_message), this resulted in strings prefixed as bytes being displayed in the channel. 
I also fixed a few lint warnings.

In __doc/example-plugins/counter.py__,  time.time() generated an AttributeError because it was a float instead of a String.
