### PR TITLE
Fixing important typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Plugins can be installed as .py files in the ```plugins/``` directory OR as a .p
 To install the example 'repeat' plugin
 
     mkdir plugins/repeat
-    cp doc/example-plugins/repeat.py plugins/repeat
+    cp doc/example-plugins/repeat.py plugins/repeat.py
 
 The repeat plugin will now be loaded by the bot on startup.
 


### PR DESCRIPTION
The `.py` appears to be important for this example to work.