### PR TITLE
Adding API Access to Plugin Context (Updated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,18 @@ Plugins can also run methods on a schedule. This allows a plugin to poll for upd
 ####Plugin misc
 The data within a plugin persists for the life of the rtmbot process. If you need persistent data, you should use something like sqlite or the python pickle libraries.
 
+####Direct API Calls
+You can directly call the Slack web API in your plugins by allowing the following import:
+
+    from client import client
+
+You can also rename the client on import so it can be easily referenced like shown below:
+
+    from client import client as sc
+
+Direct API calls can be called in your plugins in the following form:
+    
+    sc.api_call("API.method", "parameters")
+
 ####Todo:
 Some rtm data should be handled upstream, such as channel and user creation. These should create the proper objects on-the-fly.

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ Plugins can also run methods on a schedule. This allows a plugin to poll for upd
 The data within a plugin persists for the life of the rtmbot process. If you need persistent data, you should use something like sqlite or the python pickle libraries.
 
 ####Direct API Calls
-You can directly call the Slack web API in your plugins by allowing the following import:
+You can directly call the Slack web API in your plugins by including the following import:
 
-    from client import client
+    from client import slack_client
 
 You can also rename the client on import so it can be easily referenced like shown below:
 
-    from client import client as sc
+    from client import slack_client as sc
 
 Direct API calls can be called in your plugins in the following form:
     

--- a/client.py
+++ b/client.py
@@ -4,7 +4,7 @@ from rtmbot import RtmBot
 slack_client = None
 
 def init(config):
-    global client
+    global slack_client
     bot = RtmBot(config)
     slack_client = bot.slack_client
     return bot

--- a/client.py
+++ b/client.py
@@ -1,0 +1,10 @@
+from slackclient import SlackClient
+from rtmbot import RtmBot
+
+client = None
+
+def init(config):
+    global client
+    bot = RtmBot(config)
+    client = bot.slack_client
+    return bot

--- a/client.py
+++ b/client.py
@@ -1,10 +1,10 @@
 from slackclient import SlackClient
 from rtmbot import RtmBot
 
-client = None
+slack_client = None
 
 def init(config):
     global client
     bot = RtmBot(config)
-    client = bot.slack_client
+    slack_client = bot.slack_client
     return bot

--- a/client.py
+++ b/client.py
@@ -1,7 +1,7 @@
-from slackclient import SlackClient
 from rtmbot import RtmBot
 
 slack_client = None
+
 
 def init(config):
     global slack_client

--- a/docs/example-plugins/directAPIcall.py
+++ b/docs/example-plugins/directAPIcall.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from client import client as sc
+from client import slack_client as sc
 
 for user in sc.api_call("users.list")["members"]:
     print(user["name"], user["id"])

--- a/docs/example-plugins/directAPIcall.py
+++ b/docs/example-plugins/directAPIcall.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+from client import client as sc
+
+for user in sc.api_call("users.list")["members"]:
+    print(user["name"], user["id"])

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -7,6 +7,7 @@ import client
 
 sys.path.append(os.getcwd())
 
+
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument(

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
+from argparse import ArgumentParser
 import sys
 import os
-sys.path.append(os.getcwd())
-
-from argparse import ArgumentParser
-
 import yaml
 import client
 
+sys.path.append(os.getcwd())
 
 def parse_args():
     parser = ArgumentParser()

--- a/rtmbot.py
+++ b/rtmbot.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 import sys
+import os
+sys.path.append(os.getcwd())
+
 from argparse import ArgumentParser
 
 import yaml
-from rtmbot import RtmBot
+import client
 
 
 def parse_args():
@@ -19,7 +22,7 @@ def parse_args():
 # load args with config path
 args = parse_args()
 config = yaml.load(open(args.config or 'rtmbot.conf', 'r'))
-bot = RtmBot(config)
+bot = client.init(config)
 try:
     bot.start()
 except KeyboardInterrupt:

--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -48,7 +48,7 @@ class RtmBot(object):
         # initialize stateful fields
         self.last_ping = 0
         self.bot_plugins = []
-        self.slack_client = None
+        self.slack_client = SlackClient(self.token)
 
     def _dbg(self, debug_string):
         if self.debug:
@@ -56,7 +56,6 @@ class RtmBot(object):
 
     def connect(self):
         """Convenience method that creates Server instance"""
-        self.slack_client = SlackClient(self.token)
         self.slack_client.rtm_connect()
 
     def _start(self):


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Adds the ability to call the API directly within the plugin context.  The concept was adapted from PR #20 written by @zbarahal.  Few differences differentiate between their implementation and mine.  His requires slightly heavier adjustments to the RtmBot object class definition.  Mine only requires two changes in the definition.  Additionally mine is compatible and ready to merge with the current master

Notable changes:

- the line in the `RtmBot.connect()` method that instantiates the slack_client instance has been moved to the `__init__` method. 
- `import os` and adds `os.getcwd()` to `sys.path` in order for plugins to be able to import newly added file, client.py
- instantiate a global variable, `slack_client` which can be access directly within plugins to make direct Web API calls.


#### Related Issues
could potentially fix and close issues #29 #48 #49 and #50 because of the ability to format messages with direct API calls.

#### Test strategy
Created a sample plugin that calls from the API instance, and prints out each user and their user ID.  This can be found in docs/example-plugin/directAPIcall.py