### PR TITLE
Corrected markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The repeat plugin will now be loaded by the bot on startup. Run `rtmbot` from co
 Create Plugins
 --------
 
-####Incoming data
+#### Incoming data
 All events from the RTM websocket are sent to the registered plugins. To act on an event, create a function definition, inside your Plugin class, called process_(api_method) that accepts a single arg for data. For example, to handle incoming messages:
 
     def process_message(self, data):
@@ -129,9 +129,9 @@ For a list of all possible API Methods, look here: https://api.slack.com/rtm
 
 Note: If you're using Python 2.x, the incoming data should be a unicode string, be careful you don't coerce it into a normal str object as it will cause errors on output. You can add `from __future__ import unicode_literals` to your plugin file to avoid this.
 
-####Outgoing data
+#### Outgoing data
 
-#####RTM Output
+##### RTM Output
 Plugins can send messages back to any channel or direct message. This is done by appending a two item array to the Plugin's output array (```myPluginInstance.output```). The first item in the array is the channel or DM ID and the second is the message text. Example that writes "hello world" when the plugin is started:
 
     class myPlugin(Plugin):
@@ -139,7 +139,7 @@ Plugins can send messages back to any channel or direct message. This is done by
         def process_message(self, data):
             self.outputs.append(["C12345667", "hello world"])
 
-#####SlackClient Web API Output
+##### SlackClient Web API Output
 Plugins also have access to the connected SlackClient instance for more complex output (or to fetch data you may need).
 
     def process_message(self, data):
@@ -148,7 +148,7 @@ Plugins also have access to the connected SlackClient instance for more complex 
             username="pybot", icon_emoji=":robot_face:"
 
 
-####Timed jobs
+#### Timed jobs
 Plugins can also run methods on a schedule. This allows a plugin to poll for updates or perform housekeeping during its lifetime. Jobs define a run() method and return any outputs to be sent to channels. They also have access to a SlackClient instance that allows them to make calls to the Slack Web API.
 
 For example, this will print "hello world" every 10 seconds. You can output multiple messages two the same or different channels by passing multiple pairs of [Channel, Message] combos.
@@ -169,5 +169,5 @@ For example, this will print "hello world" every 10 seconds. You can output mult
             self.jobs.append(job)
 
 
-####Plugin misc
+#### Plugin misc
 The data within a plugin persists for the life of the rtmbot process. If you need persistent data, you should use something like sqlite or the python pickle libraries.


### PR DESCRIPTION
Seems that some markdown headings lacks of a space, causing to render the #symbols literally once markdown is rendered

* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> e.g. New functionality for producing whatsits.

Corrected some of the readmes headings

#### Related Issues
> e.g. Fixes #206 and closes #230

Does not apply

#### Test strategy
> e.g. Add tests around whatsit production.

Does not apply
