### PR TITLE
remove debug from readme, this actually causes errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ For example, this will print "hello world" every 10 seconds. You can output mult
     class myPlugin(Plugin):
 
         def register_jobs(self):
-            job = myJob(10, debug=True)
+            job = myJob(10)
             self.jobs.append(job)
 ```
 #### Plugin misc


### PR DESCRIPTION
The Job example in the readme doesn't work. if you remove this, then it does. Hopefully this will save others some frustration.