### PR TITLE
Implement passing configuration over environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Installation
 
 For example, if your python path includes '/path/to/myproject' and you include `plugins.repeat.RepeatPlugin` in ACTIVE_PLUGINS, it will find the RepeatPlugin class within /path/to/myproject/plugins/repeat.py and instantiate it, then attach it to your running RTMBot.
 
+### Environment variables
+
+All of the configurations variables mentioned can be overriden using environment
+variables. For example, the following will override slack token.
+
+    $ SLACK_TOKEN="xoxb-foo-bar" rtmbot
+
+This is especially useful when you want or need to hide credentials.
+
 A Word on Structure
 -------
 To give you a quick sense of how this library is structured, there is a RtmBot class which does the setup and handles input and outputs of messages. It will also search for and register Plugins within the specified directory(ies). These Plugins handle different message types with various methods and can also register periodic Jobs which will be executed by the Plugins.
@@ -125,6 +134,29 @@ The repeat plugin will now be loaded by the bot on startup. Run `rtmbot` from co
 
 ```
     rtmbot
+```
+
+###  Configuration
+
+You can configure your plugins using `rtmbot.conf` and environment variables.
+For example, running the following
+
+    $ REPEAT_PLUGIN_DUMMY_VARIABLE="true" rtmbot
+
+will result in effectively same as the following `rtmbot.conf`:
+
+```
+        plugins.repeat.RepeatPlugin:
+            dummy_variable: "true"
+```
+
+Note that environment variable values are treated as strings. If you need to
+override for example lists, booleans or numbers, handle it in your plugin. Plugin
+configuration can be accessed in the plugin from `self.plugin_config`.
+
+```python
+    def process_message(self, data):
+        print(self.plugin_config['dummy_variable']) # prints "true"
 ```
 
 Create Plugins

--- a/rtmbot/bin/run_rtmbot.py
+++ b/rtmbot/bin/run_rtmbot.py
@@ -32,7 +32,6 @@ def load_overrides_from_env(config):
     '''
     Read and apply overrides from environment variables. For plugins, name of the class
     is turned into a prefix. For example:
-    
         YourAwesomePlugin.foo_bar => YOUR_AWESOME_PLUGIN_FOO_BAR
     '''
     def boolish(v):
@@ -52,7 +51,6 @@ def load_overrides_from_env(config):
         param['name']: param['type'](os.environ[param['name']])
         for param in params
         if param['name'] in os.environ})
-
 
     # Override plugin-specific variables. Since we don't know a schema,
     # treat values as string. Leave type conversion for plugins themselves.

--- a/rtmbot/bin/run_rtmbot.py
+++ b/rtmbot/bin/run_rtmbot.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 import sys
 import os
 import yaml
+import re
 
 from rtmbot import RtmBot
 
@@ -20,12 +21,63 @@ def parse_args():
     return parser.parse_args()
 
 
+def prefix_from_plugin_name(name):
+    basename = name.split('.')[-1]
+    # Attribution: https://stackoverflow.com/a/1176023
+    splitted = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', basename)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', splitted).upper() + '_'
+
+
+def load_overrides_from_env(config):
+    '''
+    Read and apply overrides from environment variables. For plugins, name of the class
+    is turned into a prefix. For example:
+    
+        YourAwesomePlugin.foo_bar => YOUR_AWESOME_PLUGIN_FOO_BAR
+    '''
+    def boolish(v):
+        return v == '1' or v == 'true'  # bool('false') == True, so do it the hard way
+
+    params = [
+        {'name': 'SLACK_TOKEN', 'type': str},
+        {'name': 'BASE_PATH', 'type': str},
+        {'name': 'LOGFILE', 'type': str},
+        {'name': 'DEBUG', 'type': boolish},
+        {'name': 'DAEMON', 'type': boolish}
+    ]
+
+    # Override the rtmbot-specific variables. Here we can take advantage
+    # of the fact that we know what type they are supposed to be in.
+    config.update({
+        param['name']: param['type'](os.environ[param['name']])
+        for param in params
+        if param['name'] in os.environ})
+
+
+    # Override plugin-specific variables. Since we don't know a schema,
+    # treat values as string. Leave type conversion for plugins themselves.
+    for plugin in config.get('ACTIVE_PLUGINS', []):
+        prefix = prefix_from_plugin_name(plugin)
+        plugin_configs = [
+            var for var in os.environ
+            if var.startswith(prefix)]
+
+        # Create if necessary
+        if plugin not in config:
+            config[plugin] = {}
+
+        config[plugin].update({
+            param.split(prefix)[-1].lower(): os.environ[param]
+            for param in plugin_configs})
+
+
 def main(args=None):
     # load args with config path if not specified
     if not args:
         args = parse_args()
 
     config = yaml.load(open(args.config or 'rtmbot.conf', 'r'))
+    load_overrides_from_env(config)
     bot = RtmBot(config)
     try:
         bot.start()

--- a/tests/test_rtmbot_runner.py
+++ b/tests/test_rtmbot_runner.py
@@ -43,7 +43,8 @@ def test_normal_overrides():
         assert config == expected
 
 def test_plugin_overrides():
-    config = {'ACTIVE_PLUGINS': ['plugins.AwesomePlugin']}
+    config = {
+        'ACTIVE_PLUGINS': ['plugins.AwesomePlugin']}
 
     override = {
         'AWESOME_PLUGIN_FOO': '1',
@@ -55,5 +56,24 @@ def test_plugin_overrides():
         expected = {
             'foo': '1',
             'bar_bar': 'some_awesome_value'
+        }
+        assert config['plugins.AwesomePlugin'] == expected
+
+def test_plugin_config_already_exists():
+    config = {
+        'ACTIVE_PLUGINS': ['plugins.AwesomePlugin'],
+        'plugins.AwesomePlugin': {
+            'some_credential': 'foo'
+        }
+    }
+
+    override = {
+        'AWESOME_PLUGIN_SOME_CREDENTIAL': 'bar'
+    }
+
+    with override_env(override):
+        load_overrides_from_env(config)
+        expected = {
+            'some_credential': 'bar'
         }
         assert config['plugins.AwesomePlugin'] == expected

--- a/tests/test_rtmbot_runner.py
+++ b/tests/test_rtmbot_runner.py
@@ -1,0 +1,59 @@
+import os
+
+from contextlib import contextmanager
+from rtmbot.bin.run_rtmbot import load_overrides_from_env
+
+@contextmanager
+def override_env(env):
+    _environ = dict(os.environ)
+    try:
+        os.environ.clear()
+        os.environ.update(env)
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(_environ)
+
+def test_normal_overrides():
+    config = {
+        'SLACK_TOKEN': 'xoxb-foo-bar',
+        'BASE_PATH': os.getcwd(),
+        'LOGFILE': 'foobar.log',
+        'DEBUG': True,
+        'DAEMON': True
+    }
+
+    override = {
+        'SLACK_TOKEN': 'xoxb-this-should-change',
+        'BASE_PATH': '/opt/nope',
+        'LOGFILE': 'awesome.log',
+        'DEBUG': 'false',
+        'DAEMON': 'false'
+    }
+
+    with override_env(override):
+        load_overrides_from_env(config)
+        expected = {
+            'SLACK_TOKEN': 'xoxb-this-should-change',
+            'BASE_PATH': '/opt/nope',
+            'LOGFILE': 'awesome.log',
+            'DEBUG': False,
+            'DAEMON': False
+        }
+        assert config == expected
+
+def test_plugin_overrides():
+    config = {'ACTIVE_PLUGINS': ['plugins.AwesomePlugin']}
+
+    override = {
+        'AWESOME_PLUGIN_FOO': '1',
+        'AWESOME_PLUGIN_BAR_BAR': 'some_awesome_value'
+    }
+
+    with override_env(override):
+        load_overrides_from_env(config)
+        expected = {
+            'foo': '1',
+            'bar_bar': 'some_awesome_value'
+        }
+        assert config['plugins.AwesomePlugin'] == expected


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

This pull request adds functionality for overriding configuration file content from environment variables.
For example:

    $ SLACK_TOKEN="xoxb-foo-bar" REPEAT_PLUGIN_DUMMY_VARIABLE="true" rtmbot

This will result in effectively the following `rtmbot.conf`:

    SLACK_TOKEN: "xoxb-foo-bar"
    plugins.repeat.RepeatPlugin:
        dummy_variable: "true"

All rtmbot-specific configuration variables can overridden. For plugin-specific configuration
I left the limitation of treating all values as strings to keep code from getting overly complex.

All this is mentioned in the `README.md` that is also updated by this pull request.

#### Related Issues

Implements at least the environment variable portion of #89. 

#### Test strategy

`tests/test_rtmbot_runner.py` includes unit tests that cover most usual cases that came to mind.
