### PR TITLE
Fix bot output when it's to a user

### DIFF
--- a/rtmbot/core.py
+++ b/rtmbot/core.py
@@ -122,7 +122,7 @@ class RtmBot(object):
                 # things that start with U are users. convert to an IM channel.
                 if destination.startswith('U'):
                     try:
-                        result = json.loads(self.slack_client.api_call('im.open', user=destination))
+                        result = self.slack_client.api_call('im.open', user=destination)
                     except ValueError:
                         self._dbg("Parse error on im.open call results!")
                     channel = self.slack_client.server.channels.find(


### PR DESCRIPTION
This seems to return a dict rather than a string. Looks like there was a similar fix for group messaging here: https://github.com/slackapi/python-rtmbot/commit/bba41f43d99dd5dd3ed513e69291ac5953946629#diff-933761be909a15a181706d770d010687